### PR TITLE
add type=“button” to dialog buttons

### DIFF
--- a/Source/MooEditable/MooEditable.js
+++ b/Source/MooEditable/MooEditable.js
@@ -1886,7 +1886,7 @@ MooEditable.UI.AlertDialog = function(alertText){
     if (!alertText) return;
     var html = alertText 
        + '<div class="mooeditable-dialog-actions">'
-       +   '<button class="dialog-ok-button">' + MooEditable.Locale.get('ok') + '</button>'
+       +   '<button type="button" class="dialog-ok-button">' + MooEditable.Locale.get('ok') + '</button>'
        + '</div>';
     return new MooEditable.UI.Dialog(html, {
         'class': 'mooeditable-alert-dialog',
@@ -1908,9 +1908,9 @@ MooEditable.UI.PromptDialog = function(questionText, answerText, fn){
     if (!questionText) return;
     var html = '<label class="dialog-label">' + questionText
         + ' <input type="text" class="text dialog-input" value="' + answerText + '">'
-        + '</label> <button class="dialog-button dialog-ok-button">' + MooEditable.Locale.get('ok') + '</button>'
+        + '</label> <button type="button" class="dialog-button dialog-ok-button">' + MooEditable.Locale.get('ok') + '</button>'
         + '<div class="mooeditable-dialog-actions">'
-        + '  <button class="dialog-button dialog-cancel-button">' + MooEditable.Locale.get('cancel') + '</button>'
+        + '  <button type="button" class="dialog-button dialog-cancel-button">' + MooEditable.Locale.get('cancel') + '</button>'
         + '</div>';
     return new MooEditable.UI.Dialog(html, {
         'class': 'mooeditable-prompt-dialog',


### PR DESCRIPTION
avoids default type=“submit” if using any actions (createlink, urlimage) that have dialogs.

(never mind, realized updated code has fixed this!)
